### PR TITLE
Add support for close to last app with gadget bridge

### DIFF
--- a/app/src/main/java/com/matejdro/pebbledialer/modules/SystemModule.java
+++ b/app/src/main/java/com/matejdro/pebbledialer/modules/SystemModule.java
@@ -356,10 +356,15 @@ public class SystemModule extends CommModule
     {
         Timber.d("CloseApp %s", currentRunningApp);
 
-        if (getService().getGlobalSettings().getBoolean("closeToLastApp", false) && canCloseToApp(currentRunningApp) && closeTries < 2)
+        boolean closeToLastApp = getService().getGlobalSettings()
+                .getBoolean("closeToLastApp", false);
+
+        if (closeToLastApp && canCloseToApp(currentRunningApp) && closeTries < 2)
             PebbleKit.startAppOnPebble(getService(), currentRunningApp);
-        else
-            PebbleKit.closeAppOnPebble(getService(), PebbleDialerApplication.WATCHAPP_UUID);
+        else {
+            PebbleKit.closeAppOnPebble(getService(), PebbleDialerApplication.WATCHAPP_UUID, closeToLastApp);
+        }
+
 
         closeTries++;
     }

--- a/app/src/main/res/values/string_settings.xml
+++ b/app/src/main/res/values/string_settings.xml
@@ -16,7 +16,7 @@
     <string name="setting_respect_do_not_interrupt">Respect phone\'s do not disturb mode.</string>
     <string name="setting_respect_do_not_interrupt_description">Do not popup incoming call screen on the watch when phone is put into do not disturb mode.</string>
     <string name="setting_close_to_last_app">Close to last app</string>
-    <string name="setting_close_to_last_app_description">When call ends, close to last used app on Pebble. NEEDS DEVELOPER CONNECTION ENABLED INSIDE PEBBLE APP!</string>
+    <string name="setting_close_to_last_app_description">When call ends, close to last used app on Pebble. This option works if you are using Gadget Bridge or if you enable developer connection in official Pebble app.</string>
     <string name="setting_root_mode">Root mode</string>
     <string name="setting_root_mode_description">Check this if some in-call features (like answer or mic mute) do not work for you. NEEDS ROOT!</string>
     <string name="setting_light_screen_on_call">Turn on light on call</string>


### PR DESCRIPTION
Ability to close to last app was [merged into GadgetBridge](https://github.com/Freeyourgadget/Gadgetbridge/pull/1492) a while ago. This PR is a bit overdue, but here it is anyway.

It enables users of Dialer and GadgetBridge to use "Close to last app" feature which was so far only available when developer connection is enabled in official Pebble app.

Note that this also fast forwards `PebbleAndroidCommons` to https://github.com/matejdro/PebbleAndroidCommons/commit/b83870d33723e6cd9e10267fc240b1034135dcd8