### PR TITLE
Add workaround for starting calls from the watch on Android 10+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.WRITE_SMS" />
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application
         android:name=".PebbleDialerApplication"


### PR DESCRIPTION
At the moment, starting calls from the watch does not work on Android 10+ since no background apps are allowed to open up new window (and starting a call is considered as opening new window).

This PR enables the workaround by giving the app system alert window permission. After install, user must go to System Settings -> Apps -> Special app access -> Display over other apps -> Find Dialer for Rebble -> Check "Allow display over other apps". Then Dialer should be able to start call normally from the watch.